### PR TITLE
Fix warning for `Base.Bool`

### DIFF
--- a/src/Float8s.jl
+++ b/src/Float8s.jl
@@ -4,7 +4,7 @@ module Float8s
                 isnan,iszero,one,zero,abs,isfinite,
                 floatmin,floatmax,typemin,typemax,
                 Float16,Float32,Float64,
-                UInt8,Int8,Int16,Int32,Int64,
+                Bool,UInt8,Int8,Int16,Int32,Int64,
                 (+), (-), (*), (/), (\), (^),
                 sin,cos,tan,asin,acos,atan,sinh,cosh,tanh,asinh,acosh,
                 atanh,exp,exp2,exp10,expm1,log,log2,log10,sqrt,cbrt,log1p,


### PR DESCRIPTION

```
┌ Float8s
│  WARNING: Constructor for type "Bool" was extended in `Float8s` without explicit qualification or import.
│    NOTE: Assumed "Bool" refers to `Base.Bool`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Bool end`.
│    Hint: To silence the warning, qualify `Bool` as `Base.Bool` in the method signature or explicitly `import Base: Bool`.
└  
```
https://github.com/JuliaMath/Float8s.jl/actions/runs/19420688503/job/55557294147#step:6:69
